### PR TITLE
CL-1: Create ClauseAI project README and documentation

### DIFF
--- a/prototypes/ClauseAI/README.md
+++ b/prototypes/ClauseAI/README.md
@@ -1,0 +1,68 @@
+# ClauseAI
+
+AI-powered legal document assistant that simplifies the creation of professional legal agreements.
+
+## About
+
+ClauseAI transforms complex legal document creation into a simple, conversational experience. Powered by advanced language models, it guides users through the process of generating customized legal agreements from professionally curated templates.
+
+**Target Users:**
+- Small businesses needing standard legal agreements
+- Startups requiring NDAs, service agreements, and contracts
+- Individuals navigating legal document requirements
+
+**Core Value:**
+- Accessible legal documentation without expensive attorney consultations
+- Guided, conversational interface reduces complexity
+- Pre-vetted templates from trusted legal sources (CommonPaper)
+
+## Project Status
+
+This project is in active development. See [PLAN.md](./PLAN.md) for the complete roadmap.
+
+**Current Phase:** CL-1 (Foundation)
+
+**Planned Features:**
+- Conversational AI chat interface for document creation
+- Template library covering common legal agreements
+- Real-time document preview and editing
+- Multi-user support with document management dashboard
+- PDF export for professional delivery
+
+## Technology Vision
+
+**Frontend:** Next.js with TypeScript, React, and Tailwind CSS  
+**Backend:** FastAPI (Python) with SQLite  
+**AI:** Claude API for intelligent document generation  
+**Deployment:** Docker containerization for local and cloud deployment
+
+## Design Direction
+
+ClauseAI adopts a professional legal-tech aesthetic that balances authority with approachability.
+
+**Color Palette:**
+- Deep Navy: `#0A1929` - Primary interface elements, headers
+- Steel Blue: `#1E4976` - Secondary actions, links
+- Gold Accent: `#C9A961` - Premium features, highlights
+- Slate Gray: `#64748B` - Supporting text, labels
+- Success Green: `#10B981` - Confirmation states, approval
+
+**Design Principles:**
+- Clean, minimal interface reducing cognitive load
+- Clear visual hierarchy for legal content
+- Trustworthy, professional typography
+- Accessibility-first approach
+
+## Legal Notice
+
+All document templates are sourced from CommonPaper (https://github.com/CommonPaper) and licensed under CC BY 4.0. ClauseAI provides document generation tools but does not offer legal advice. Users should consult qualified legal professionals for specific legal guidance.
+
+## Development
+
+This is an experimental prototype built using agentic coding workflows within the [agentic-sandbox](../../) project.
+
+**Documentation:**
+- [PLAN.md](./PLAN.md) - Development roadmap with 7-phase implementation
+- More documentation will be added as the project evolves
+
+**License:** MIT (for code); CC BY 4.0 (for templates)

--- a/prototypes/README.md
+++ b/prototypes/README.md
@@ -18,6 +18,21 @@ A full-stack, AI-augmented Kanban board application.
 - AI sidebar for natural language board management
 - Drag-and-drop task management
 
+### [ClauseAI](./ClauseAI)
+AI-powered legal document assistant for generating professional legal agreements.
+
+**Stack:**
+- Frontend: Next.js (TypeScript, React) + Tailwind CSS
+- Backend: FastAPI (Python) + SQLite
+- AI: Claude API for intelligent document generation
+
+**Key Features:**
+- Conversational AI interface for document creation
+- Template library from CommonPaper (CC BY 4.0)
+- Real-time document preview and editing
+- Multi-user support with document dashboard
+- PDF export capability
+
 ---
 
 ## About This Directory


### PR DESCRIPTION
## Summary
Creates initial README for ClauseAI project (CL-1), an AI-powered legal document assistant. Establishes project foundation with professional legal-tech branding and clear development direction.

## Changes
- Add `ClauseAI/README.md` with comprehensive project overview
- Update `prototypes/README.md` to list ClauseAI alongside Kanban Studio
- Define legal-tech color palette (Deep Navy, Steel Blue, Gold Accent, Slate Gray, Success Green)
- Document technology vision (Next.js + FastAPI + Claude API)
- Include legal notices and licensing information

## Test Plan
- [x] README renders correctly in GitHub
- [x] Links to PLAN.md work properly
- [x] Content follows repository documentation conventions (no emojis, minimal style)
- [x] Legal-tech aesthetic and color palette clearly defined

## Related Issues
Closes #12

## Jira
https://enterthematrix.atlassian.net/browse/CL-1